### PR TITLE
[DPE-3374] Add authorization servlet filter logic

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,8 @@ options:
       Configures the log level.
     default: "info"
     type: string
+  authorized-users:
+    description: |
+      Comma separated list of authorized users. By default all users (*) are authorized.
+    default: "*"
+    type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,7 +20,7 @@ resources:
   spark-history-server-image:
     type: oci-image
     description: OCI image for Spark History Server
-    upstream-source: ghcr.io/canonical/charmed-spark:3.4-22.04_stable
+    upstream-source: ghcr.io/canonical/charmed-spark:3.4-22.04_edge
 
 requires:
   s3-credentials:

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Limited
+# Copyright 2024 Canonical Limited
 # See LICENSE file for licensing details.
 #
 # Learn more at: https://juju.is/docs/sdk

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -39,7 +39,7 @@ class Context(WithLogging):
     @property
     def authorized_users(self) -> str | None:
         """The comma-separated list of authorized users."""
-        return self.charm.config[AUTHORIZED_USERS]
+        return self.charm.config[AUTHORIZED_USERS] if self._oathkeeper_relation else None
 
     # -----------------
     # --- RELATIONS ---

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -17,8 +17,8 @@ from core.domain import S3ConnectionInfo
 S3 = "s3-credentials"
 INGRESS = "ingress"
 OATHKEEPER = "auth-proxy"
-
-AUTH_PROXY_HEADERS = ["X-User"]
+AUTHORIZED_USERS = "authorized-users"
+AUTH_PROXY_HEADERS = ["X-User", "X-Email"]
 
 
 class Context(WithLogging):
@@ -36,8 +36,10 @@ class Context(WithLogging):
     # --------------
     # --- CONFIG ---
     # --------------
-    # We don't have config yet in the Spark History Server charm.
-    # --------------
+    @property
+    def authorized_users(self) -> str | None:
+        """The comma-separated list of authorized users."""
+        return self.charm.config[AUTHORIZED_USERS]
 
     # -----------------
     # --- RELATIONS ---

--- a/src/events/history_server.py
+++ b/src/events/history_server.py
@@ -41,7 +41,6 @@ class HistoryServerEvents(BaseEventHandler, WithLogging):
         self.history_server.update(
             self.context.s3,
             self.context.ingress,
-            self.context.auth_proxy_config,
             self.context.authorized_users,
         )
 
@@ -55,11 +54,10 @@ class HistoryServerEvents(BaseEventHandler, WithLogging):
         self.history_server.update(
             self.context.s3,
             self.context.ingress,
-            self.context.auth_proxy_config,
             self.context.authorized_users,
         )
         self.charm.unit.status = self.get_app_status(self.context.s3, self.context.ingress, None)
         if self.charm.unit.is_leader():
             self.charm.app.status = self.get_app_status(
-                self.context.s3, self.context.ingress, self.context.auth_proxy_config
+                self.context.s3, self.context.ingress, self.context.authorized_users
             )

--- a/src/events/ingress.py
+++ b/src/events/ingress.py
@@ -79,9 +79,7 @@ class IngressEvents(BaseEventHandler, WithLogging):
     def _on_auth_proxy_removed(self, _: AuthProxyRelationRemovedEvent):
         """Handle the removal of the AuthProxy."""
         self.logger.info("AuthProxy configuration gone")
-        self.history_server.update(
-            self.context.s3, self.context.ingress, self.context.authorized_users
-        )
+        self.history_server.update(self.context.s3, self.context.ingress, None)
 
         self.charm.unit.status = self.get_app_status(self.context.s3, self.context.ingress, None)
         if self.charm.unit.is_leader():

--- a/src/events/ingress.py
+++ b/src/events/ingress.py
@@ -44,13 +44,21 @@ class IngressEvents(BaseEventHandler, WithLogging):
         self.framework.observe(
             self.auth_proxy.on.auth_proxy_relation_removed, self._on_auth_proxy_removed
         )
+        self.framework.observe(
+            self.charm.on[OATHKEEPER].relation_changed, self._on_auth_proxy_changed
+        )
 
     @compute_status
     def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
         """Handle the `IngressPerAppReadyEvent`."""
         self.logger.info("This app's ingress URL: %s", event.url)
 
-        self.history_server.update(self.context.s3, self.context.ingress)
+        self.history_server.update(
+            self.context.s3,
+            self.context.ingress,
+            self.context.auth_proxy_config,
+            self.context.authorized_users,
+        )
 
         # auth proxy config
         self.auth_proxy.update_auth_proxy_config(auth_proxy_config=self.context.auth_proxy_config)
@@ -58,7 +66,7 @@ class IngressEvents(BaseEventHandler, WithLogging):
     def _on_ingress_revoked(self, _: IngressPerAppRevokedEvent):
         """Handle the `IngressPerAppRevokedEvent`."""
         self.log_result("This app no longer has ingress")(
-            self.history_server.update(self.context.s3, None)
+            self.history_server.update(self.context.s3, None, None, self.context.authorized_users)
         )
 
         self.charm.unit.status = self.get_app_status(
@@ -72,10 +80,29 @@ class IngressEvents(BaseEventHandler, WithLogging):
     def _on_auth_proxy_removed(self, _: AuthProxyRelationRemovedEvent):
         """Handle the removal of the AuthProxy."""
         self.logger.info("AuthProxy configuration gone")
-        self.history_server.update(self.context.s3, self.context.ingress)
+        self.history_server.update(
+            self.context.s3, self.context.ingress, None, self.context.authorized_users
+        )
 
         self.charm.unit.status = self.get_app_status(self.context.s3, self.context.ingress, None)
         if self.charm.unit.is_leader():
             self.charm.app.status = self.get_app_status(
                 self.context.s3, self.context.ingress, None
+            )
+
+    @compute_status
+    def _on_auth_proxy_changed(self, _: AuthProxyRelationRemovedEvent):
+        """Handle the removal of the AuthProxy."""
+        self.logger.info("AuthProxy configuration gone")
+        self.history_server.update(
+            self.context.s3,
+            self.context.ingress,
+            self.context.auth_proxy_config,
+            self.context.authorized_users,
+        )
+
+        self.charm.unit.status = self.get_app_status(self.context.s3, self.context.ingress, None)
+        if self.charm.unit.is_leader():
+            self.charm.app.status = self.get_app_status(
+                self.context.s3, self.context.ingress, self.context.auth_proxy_config
             )

--- a/src/events/ingress.py
+++ b/src/events/ingress.py
@@ -13,7 +13,7 @@ from charms.traefik_k8s.v2.ingress import (
     IngressPerAppRequirer,
     IngressPerAppRevokedEvent,
 )
-from ops import CharmBase
+from ops import CharmBase, RelationChangedEvent
 
 from common.utils import WithLogging
 from core.context import INGRESS, OATHKEEPER, Context
@@ -56,7 +56,6 @@ class IngressEvents(BaseEventHandler, WithLogging):
         self.history_server.update(
             self.context.s3,
             self.context.ingress,
-            self.context.auth_proxy_config,
             self.context.authorized_users,
         )
 
@@ -66,7 +65,7 @@ class IngressEvents(BaseEventHandler, WithLogging):
     def _on_ingress_revoked(self, _: IngressPerAppRevokedEvent):
         """Handle the `IngressPerAppRevokedEvent`."""
         self.log_result("This app no longer has ingress")(
-            self.history_server.update(self.context.s3, None, None, self.context.authorized_users)
+            self.history_server.update(self.context.s3, None, self.context.authorized_users)
         )
 
         self.charm.unit.status = self.get_app_status(
@@ -81,7 +80,7 @@ class IngressEvents(BaseEventHandler, WithLogging):
         """Handle the removal of the AuthProxy."""
         self.logger.info("AuthProxy configuration gone")
         self.history_server.update(
-            self.context.s3, self.context.ingress, None, self.context.authorized_users
+            self.context.s3, self.context.ingress, self.context.authorized_users
         )
 
         self.charm.unit.status = self.get_app_status(self.context.s3, self.context.ingress, None)
@@ -91,18 +90,13 @@ class IngressEvents(BaseEventHandler, WithLogging):
             )
 
     @compute_status
-    def _on_auth_proxy_changed(self, _: AuthProxyRelationRemovedEvent):
-        """Handle the removal of the AuthProxy."""
-        self.logger.info("AuthProxy configuration gone")
+    def _on_auth_proxy_changed(self, _: RelationChangedEvent):
+        """Handle the change of configuration of the AuthProxy."""
+        self.logger.info("AuthProxy configuration changed.")
         self.history_server.update(
             self.context.s3,
             self.context.ingress,
-            self.context.auth_proxy_config,
             self.context.authorized_users,
         )
-
-        self.charm.unit.status = self.get_app_status(self.context.s3, self.context.ingress, None)
-        if self.charm.unit.is_leader():
-            self.charm.app.status = self.get_app_status(
-                self.context.s3, self.context.ingress, self.context.auth_proxy_config
-            )
+        # auth proxy config
+        self.auth_proxy.update_auth_proxy_config(auth_proxy_config=self.context.auth_proxy_config)

--- a/src/events/s3.py
+++ b/src/events/s3.py
@@ -40,12 +40,22 @@ class S3Events(BaseEventHandler, WithLogging):
     def _on_s3_credential_changed(self, _: CredentialsChangedEvent):
         """Handle the `CredentialsChangedEvent` event from S3 integrator."""
         self.logger.info("S3 Credentials changed")
-        self.history_server.update(self.context.s3, self.context.ingress)
+        self.history_server.update(
+            self.context.s3,
+            self.context.ingress,
+            self.context.auth_proxy_config,
+            self.context.authorized_users,
+        )
 
     def _on_s3_credential_gone(self, _: CredentialsGoneEvent):
         """Handle the `CredentialsGoneEvent` event for S3 integrator."""
         self.logger.info("S3 Credentials gone")
-        self.history_server.update(None, self.context.ingress)
+        self.history_server.update(
+            None,
+            self.context.ingress,
+            self.context.auth_proxy_config,
+            self.context.authorized_users,
+        )
 
         self.charm.unit.status = self.get_app_status(
             None, self.context.ingress, self.context.auth_proxy_config

--- a/src/events/s3.py
+++ b/src/events/s3.py
@@ -43,7 +43,6 @@ class S3Events(BaseEventHandler, WithLogging):
         self.history_server.update(
             self.context.s3,
             self.context.ingress,
-            self.context.auth_proxy_config,
             self.context.authorized_users,
         )
 
@@ -53,7 +52,6 @@ class S3Events(BaseEventHandler, WithLogging):
         self.history_server.update(
             None,
             self.context.ingress,
-            self.context.auth_proxy_config,
             self.context.authorized_users,
         )
 


### PR DESCRIPTION
This PR introduce the authorization servlet filter:
- Servlet filter activated when oathkeeper is related 
- New configuration option
- New integration tests

This PR superseded #32 