### PR TITLE
[DPE-7003] Rename azure storage interface from 'azure' to 'azure-storage'

### DIFF
--- a/lib/charms/data_platform_libs/v0/object_storage.py
+++ b/lib/charms/data_platform_libs/v0/object_storage.py
@@ -128,7 +128,7 @@ class AzureStorageRequirerEventHandlers(RequirerEventHandlers):
         event_data = {"container": self.container}
         self.relation_data.update_relation_data(event.relation.id, event_data)
 
-    def get_azure_connection_info(self) -> Dict[str, str]:
+    def get_azure_storage_connection_info(self) -> Dict[str, str]:
         """Return the azure storage connection info as a dictionary."""
         for relation in self.relations:
             if relation and relation.app:
@@ -148,7 +148,7 @@ class AzureStorageRequirerEventHandlers(RequirerEventHandlers):
 
         # check if the mandatory options are in the relation data
         contains_required_options = True
-        credentials = self.get_azure_connection_info()
+        credentials = self.get_azure_storage_connection_info()
         missing_options = []
         for configuration_option in AZURE_STORAGE_REQUIRED_INFO:
             if configuration_option not in credentials:
@@ -187,7 +187,7 @@ class AzureStorageRequirerEventHandlers(RequirerEventHandlers):
 
         # check if the mandatory options are in the relation data
         contains_required_options = True
-        credentials = self.get_azure_connection_info()
+        credentials = self.get_azure_storage_connection_info()
         missing_options = []
         for configuration_option in AZURE_STORAGE_REQUIRED_INFO:
             if configuration_option not in credentials:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -28,8 +28,8 @@ resources:
 requires:
   s3-credentials:
     interface: s3
-  azure-credentials:
-    interface: azure
+  azure-storage-credentials:
+    interface: azure-storage
   ingress:
     interface: ingress
     limit: 1

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,7 +29,7 @@ requires:
   s3-credentials:
     interface: s3
   azure-storage-credentials:
-    interface: azure-storage
+    interface: azure_storage
   ingress:
     interface: ingress
     limit: 1

--- a/src/constants.py
+++ b/src/constants.py
@@ -9,7 +9,7 @@
 CONTAINER = "spark-history-server"
 
 PEBBLE_USER = ("_daemon_", "_daemon_")
-AZURE_RELATION_NAME = "azure-credentials"
+AZURE_RELATION_NAME = "azure-storage-credentials"
 JMX_EXPORTER_PORT = 9101
 JMX_CC_PORT = 9102
 METRICS_RULES_DIR = "./src/alert_rules/prometheus"

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -163,7 +163,7 @@ class Status(Enum):
     """Class bundling all statuses that the charm may fall into."""
 
     WAITING_PEBBLE = MaintenanceStatus("Waiting for Pebble")
-    MISSING_STORAGE_RELATION = BlockedStatus("Missing relation with storage (s3 or azure)")
+    MISSING_STORAGE_RELATION = BlockedStatus("Missing relation with storage (s3 or azure storage)")
     INVALID_S3_CREDENTIALS = BlockedStatus("Invalid S3 credentials")
     MISSING_INGRESS_RELATION = BlockedStatus("Missing INGRESS relation")
     NOT_RUNNING = BlockedStatus("History server not running. Please check logs.")

--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -169,7 +169,7 @@ class HistoryServerManager(WithLogging):
         if (not s3_manager or not s3_manager.verify()) and (
             not azure_manager or not azure_manager.verify()
         ):
-            self.logger.info("Nor s3 or azure are ready")
+            self.logger.info("Neither S3 nor Azure Storage are ready")
             return
         if s3:
             if tls_ca_chain := s3.tls_ca_chain:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -97,7 +97,7 @@ def charm_versions() -> IntegrationTestsCharms:
 
 
 @pytest.fixture(scope="module")
-def azure_credentials(ops_test: OpsTest):
+def azure_storage_credentials(ops_test: OpsTest):
     return {
         "container": "test-container",
         "path": "spark-events",

--- a/tests/integration/test_charm_azure.py
+++ b/tests/integration/test_charm_azure.py
@@ -158,7 +158,13 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_versions, azure_storage
     logger.info("Setting up spark")
 
     setup_spark_output = subprocess.check_output(
-        f"./tests/integration/setup/setup_spark_azure.sh {azure_storage_credentials['container']} {azure_storage_credentials['path']} {azure_storage_credentials['storage-account']} {azure_storage_credentials['secret-key']}",
+        (
+            f"./tests/integration/setup/setup_spark_azure.sh "
+            f"{azure_storage_credentials['container']} "
+            f"{azure_storage_credentials['path']} "
+            f"{azure_storage_credentials['storage-account']} "
+            f"{azure_storage_credentials['secret-key']} {image_version}"
+        ),
         shell=True,
         stderr=None,
     ).decode("utf-8")

--- a/tests/integration/test_charm_azure.py
+++ b/tests/integration/test_charm_azure.py
@@ -29,7 +29,7 @@ BUCKET_NAME = "history-server"
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, charm_versions, azure_credentials):
+async def test_build_and_deploy(ops_test: OpsTest, charm_versions, azure_storage_credentials):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.
@@ -69,26 +69,26 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_versions, azure_credent
         ops_test,
         charm_versions.azure_storage.application_name,
         "iamsecret",
-        {"secret-key": azure_credentials["secret-key"]},
+        {"secret-key": azure_storage_credentials["secret-key"]},
     )
     logger.info(
         f"Juju secret for secret-key config option for azure-storage-integrator added. Secret URI: {credentials_secret_uri}"
     )
 
     configuration_parameters = {
-        "container": azure_credentials["container"],
-        "path": azure_credentials["path"],
-        "storage-account": azure_credentials["storage-account"],
-        "connection-protocol": azure_credentials["connection-protocol"],
+        "container": azure_storage_credentials["container"],
+        "path": azure_storage_credentials["path"],
+        "storage-account": azure_storage_credentials["storage-account"],
+        "connection-protocol": azure_storage_credentials["connection-protocol"],
         "credentials": credentials_secret_uri,
     }
 
     # create azure container
     logger.info(
-        f"Creating container {azure_credentials['container']} with path {azure_credentials['path']}"
+        f"Creating container {azure_storage_credentials['container']} with path {azure_storage_credentials['path']}"
     )
     # First delete container
-    delete_azure_container(azure_credentials["container"])
+    delete_azure_container(azure_storage_credentials["container"])
     sleep(10)
 
     # apply new configuration options
@@ -146,7 +146,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_versions, azure_credent
     logger.info("Setting up spark")
 
     setup_spark_output = subprocess.check_output(
-        f"./tests/integration/setup/setup_spark_azure.sh {azure_credentials['container']} {azure_credentials['path']} {azure_credentials['storage-account']} {azure_credentials['secret-key']}",
+        f"./tests/integration/setup/setup_spark_azure.sh {azure_storage_credentials['container']} {azure_storage_credentials['path']} {azure_storage_credentials['storage-account']} {azure_storage_credentials['secret-key']}",
         shell=True,
         stderr=None,
     ).decode("utf-8")
@@ -180,4 +180,4 @@ async def test_build_and_deploy(ops_test: OpsTest, charm_versions, azure_credent
     assert len(apps) == 1
 
     logger.info("Delete azure container!")
-    delete_azure_container(azure_credentials["container"])
+    delete_azure_container(azure_storage_credentials["container"])

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -137,7 +137,7 @@ def azure_storage_relation():
 
     return Relation(
         endpoint=AZURE_RELATION_NAME,
-        interface="azure",
+        interface="azure-storage",
         remote_app_name="azure-storage-integrator",
         relation_id=relation_id,
         local_app_data={"container": f"relation-{relation_id}"},

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -161,7 +161,7 @@ def azure_storage_relation():
 
     return Relation(
         endpoint=AZURE_RELATION_NAME,
-        interface="azure-storage",
+        interface="azure_storage",
         remote_app_name="azure-storage-integrator",
         relation_id=relation_id,
         local_app_data={"container": f"relation-{relation_id}"},

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,7 +44,7 @@ def test_pebble_ready(exec_calls, history_server_ctx, history_server_container):
         containers=[history_server_container],
     )
     out = history_server_ctx.run(history_server_container.pebble_ready_event, state)
-    assert out.unit_status == BlockedStatus("Missing relation with storage (s3 or azure)")
+    assert out.unit_status == BlockedStatus("Missing relation with storage (s3 or azure storage)")
 
 
 @patch("managers.s3.S3Manager.verify", return_value=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -170,7 +170,7 @@ def test_s3_relation_broken(
     )
 
     assert state_after_relation_broken.unit_status == BlockedStatus(
-        "Missing relation with storage (s3 or azure)"
+        "Missing relation with storage (s3 or azure storage)"
     )
 
     spark_properties = parse_spark_properties(state_after_relation_broken, tmp_path)
@@ -193,7 +193,7 @@ def test_ingress_relation_creation(
         containers=[history_server_container],
     )
     out = history_server_ctx.run(ingress_relation.changed_event, state)
-    assert out.unit_status == BlockedStatus("Missing relation with storage (s3 or azure)")
+    assert out.unit_status == BlockedStatus("Missing relation with storage (s3 or azure storage)")
 
 
 @patch("managers.s3.S3Manager.verify", return_value=True)
@@ -317,7 +317,7 @@ def test_azure_storage_relation_broken(
     )
 
     assert state_after_relation_broken.unit_status == BlockedStatus(
-        "Missing relation with storage (s3 or azure)"
+        "Missing relation with storage (s3 or azure storage)"
     )
 
     spark_properties = parse_spark_properties(state_after_relation_broken, tmp_path)


### PR DESCRIPTION
Use the new `azure_storage` relation interface instead of the old `azure` one.