### PR TITLE
[DPE-6938] Fixing flapping status metrics in the grafana dashboard

### DIFF
--- a/src/grafana_dashboards/jvm-metrics.json
+++ b/src/grafana_dashboards/jvm-metrics.json
@@ -230,7 +230,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "up{job=\"$job\", instance=\"$app$node\"}",
+            "expr": "sum_over_time(up{job=\"$job\", instance=\"$app$node\"}[1m])",
             "format": "time_series",
             "instant": true,
             "interval": "",


### PR DESCRIPTION
The PR updates the status metrics following the indication made in this [post](https://discourse.charmhub.io/t/centralized-host-health-alert-rules/16152). 

I manually tested with both spark-history-server up and down and the metric now is consistent with the behavior of charm.

This PR fixes #72