### PR TITLE
[DPE-7126] Add dependencies installation for TIOBE pipeline

### DIFF
--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -8,7 +8,6 @@ on:
   schedule:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch:
-  pull_request:
 
 
 jobs:

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -8,6 +8,7 @@ on:
   schedule:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch:
+  pull_request:
 
 
 jobs:
@@ -32,6 +33,7 @@ jobs:
         run: |
           pipx install tox
           pipx install poetry
+          poetry install --all-group
 
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -33,7 +33,14 @@ jobs:
         run: |
           pipx install tox
           pipx install poetry
+
+      - name: Create and activate virtual environment
+        run: |
+          python3 -m venv .venv
+          . .venv/bin/activate
+          pip install flake8 poetry pylint pytest tox
           poetry install --all-groups
+          echo PATH="$PATH" >> "$GITHUB_ENV"
 
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit

--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pipx install tox
           pipx install poetry
-          poetry install --all-group
+          poetry install --all-groups
 
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit


### PR DESCRIPTION
This PR address the warning of the TIOBE scan that shows that some of the dependencies like `ops`, `cosl` and others cannot be  resolved.