### PR TITLE
[MISC] Update renovate schedule and fix team name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,12 +3,12 @@
   "extends": [
     "github>canonical/data-platform//renovate_presets/charm.json5",
   ],
-  "reviewers": ["canonical/processing"],
-  // At 03:XX AM on Friday, twice a month
-  "schedule": ["* 3 1-7,15-21 * 5"],
+  "reviewers": ["canonical:processing"],
+  // Between 1AM and 4:59AM on Friday, twice a month
+  "schedule": ["* 1-4 1-7,15-21 * 5"],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["* 3 1-7,15-21 * 5"]
+    "schedule": ["* 1-4 1-7,15-21 * 5"]
   },
   "ignoreDeps": ["ubuntu"]
 }


### PR DESCRIPTION
The renovate scheduler can miss a window of a specific hour, I increased it a little bit.
\+ the team name syntax was wrong, fixed that as well