### PR TITLE
[PRA-200] Explicit proxy support for S3-compliant storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 *.charm
 .tox/
 .coverage
+coverage.xml
 __pycache__/
 *.py[cod]
 .vscode

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -4,9 +4,11 @@
 
 """Utilities."""
 
+import ipaddress
 import os
 from logging import Logger, getLogger
 from typing import Any, Callable, Literal, TypedDict, Union
+from urllib.parse import urlparse
 
 PathLike = Union[str, "os.PathLike[str]"]
 
@@ -69,3 +71,35 @@ class WithLogging:
             return x
 
         return wrap
+
+
+def is_proxy_skipped(endpoint: str) -> bool:
+    """Determine if proxy should not be applied for the given endpoint."""
+    no_proxy_list = os.environ.get("JUJU_CHARM_NO_PROXY", "")
+    if not no_proxy_list:
+        return False
+
+    host = urlparse(endpoint).hostname
+    if not host:
+        return False
+    no_proxy_entries = [
+        entry.strip().lower() for entry in no_proxy_list.split(",") if entry.strip()
+    ]
+    for entry in no_proxy_entries:
+        if host == entry:
+            return True
+        elif entry.startswith(".") and host.endswith(
+            entry
+        ):  # abc.example.com matches .example.com
+            return True
+        elif host.endswith("." + entry):  # abc.example.com matches example.com
+            return True
+        try:
+            if ipaddress.ip_address(host) in ipaddress.ip_network(
+                entry, strict=False
+            ):  # CIDR match
+                return True
+        except (AttributeError, ValueError):
+            continue
+
+    return False

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -49,9 +49,9 @@ class S3ConnectionInfo(StateBase):
         super().__init__(relation, component)
 
     @property
-    def endpoint(self) -> str | None:
+    def endpoint(self) -> str:
         """Return endpoint of the S3 bucket."""
-        return self.relation_data.get("endpoint", None)
+        return self.relation_data.get("endpoint", "")
 
     @property
     def access_key(self) -> str:

--- a/src/managers/azure_storage.py
+++ b/src/managers/azure_storage.py
@@ -30,17 +30,10 @@ class AzureStorageManager(WithLogging):
     @cached_property
     def container_client(self) -> ContainerClient:
         """Azure container client session."""
-        proxy_config: dict[str, str] = {}
-        if os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
-            proxy_config["https"] = os.environ["JUJU_CHARM_HTTPS_PROXY"]
-        if os.environ.get("JUJU_CHARM_HTTP_PROXY"):
-            proxy_config["http"] = os.environ["JUJU_CHARM_HTTP_PROXY"]
-
         return ContainerClient(
             account_url=self.config.endpoint_http,
             container_name=self.config.container,
             credential=self.config.secret_key,
-            proxies=proxy_config,
         )
 
     def get_or_create_container(self) -> bool:

--- a/src/managers/azure_storage.py
+++ b/src/managers/azure_storage.py
@@ -30,10 +30,17 @@ class AzureStorageManager(WithLogging):
     @cached_property
     def container_client(self) -> ContainerClient:
         """Azure container client session."""
+        proxy_config: dict[str, str] = {}
+        if os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
+            proxy_config["https"] = os.environ["JUJU_CHARM_HTTPS_PROXY"]
+        if os.environ.get("JUJU_CHARM_HTTP_PROXY"):
+            proxy_config["http"] = os.environ["JUJU_CHARM_HTTP_PROXY"]
+
         return ContainerClient(
             account_url=self.config.endpoint_http,
             container_name=self.config.container,
             credential=self.config.secret_key,
+            proxies=proxy_config,
         )
 
     def get_or_create_container(self) -> bool:

--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -70,14 +70,15 @@ class HistoryServerConfig(WithLogging):
     def _s3_conf(self) -> dict[str, str]:
         if (s3 := self.s3) and s3.verify():
             return {
-                "spark.hadoop.fs.s3a.endpoint": s3.config.endpoint or "https://s3.amazonaws.com",
-                "spark.hadoop.fs.s3a.access.key": s3.config.access_key,
-                "spark.hadoop.fs.s3a.secret.key": s3.config.secret_key,
-                "spark.eventLog.dir": s3.config.log_dir,
-                "spark.history.fs.logDirectory": s3.config.log_dir,
+                "spark.hadoop.fs.s3a.endpoint": s3.connection_info.endpoint
+                or "https://s3.amazonaws.com",
+                "spark.hadoop.fs.s3a.access.key": s3.connection_info.access_key,
+                "spark.hadoop.fs.s3a.secret.key": s3.connection_info.secret_key,
+                "spark.eventLog.dir": s3.connection_info.log_dir,
+                "spark.history.fs.logDirectory": s3.connection_info.log_dir,
                 "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
                 "spark.hadoop.fs.s3a.connection.ssl.enabled": self._ssl_enabled(
-                    s3.config.endpoint
+                    s3.connection_info.endpoint
                 ),
             }
         return {}

--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -4,9 +4,11 @@
 
 """History Server manager."""
 
+import os
 import re
+from urllib.parse import ParseResult, urlparse
 
-from common.utils import WithLogging
+from common.utils import WithLogging, is_proxy_skipped
 from core.context import (
     AUTH_PROXY_HEADERS,
     OAUTH2_PROXY_HEADERS,
@@ -68,20 +70,76 @@ class HistoryServerConfig(WithLogging):
 
     @property
     def _s3_conf(self) -> dict[str, str]:
-        if (s3 := self.s3) and s3.verify():
-            return {
-                "spark.hadoop.fs.s3a.endpoint": s3.connection_info.endpoint
-                or "https://s3.amazonaws.com",
-                "spark.hadoop.fs.s3a.access.key": s3.connection_info.access_key,
-                "spark.hadoop.fs.s3a.secret.key": s3.connection_info.secret_key,
-                "spark.eventLog.dir": s3.connection_info.log_dir,
-                "spark.history.fs.logDirectory": s3.connection_info.log_dir,
-                "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
-                "spark.hadoop.fs.s3a.connection.ssl.enabled": self._ssl_enabled(
-                    s3.connection_info.endpoint
+        if (s3 := self.s3) is None or not s3.verify():
+            return {}
+
+        base_s3_conf = {
+            "spark.hadoop.fs.s3a.endpoint": s3.connection_info.endpoint
+            or "https://s3.amazonaws.com",
+            "spark.hadoop.fs.s3a.access.key": s3.connection_info.access_key,
+            "spark.hadoop.fs.s3a.secret.key": s3.connection_info.secret_key,
+            "spark.eventLog.dir": s3.connection_info.log_dir,
+            "spark.history.fs.logDirectory": s3.connection_info.log_dir,
+            "spark.hadoop.fs.s3a.aws.credentials.provider": "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider",
+            "spark.hadoop.fs.s3a.connection.ssl.enabled": self._ssl_enabled(
+                s3.connection_info.endpoint
+            ),
+        }
+
+        # Assigns the first non empty proxy url or defaults to an empty string
+        proxy_url = next(
+            filter(
+                None,
+                (
+                    os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+                    os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
                 ),
-            }
-        return {}
+            ),
+            "",
+        )
+        if is_proxy_skipped(s3.connection_info.endpoint):
+            proxy_conf = {}
+        else:
+            match urlparse(proxy_url):
+                case ParseResult(
+                    username=str(username),
+                    password=str(password),
+                    hostname=str(hostname),
+                    port=port,
+                    scheme=scheme,
+                ) if scheme in ("http", "https"):
+                    port = port if port else 80
+
+                    proxy_conf = {
+                        "spark.hadoop.fs.s3a.proxy.host": hostname,
+                        "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
+                        if scheme == "https"
+                        else "false",
+                        "spark.hadoop.fs.s3a.proxy.port": port,
+                        "spark.hadoop.fs.s3a.proxy.username": username,
+                        "spark.hadoop.fs.s3a.proxy.password": password,
+                    }
+
+                case ParseResult(
+                    username=None,
+                    password=None,
+                    hostname=str(hostname),
+                    port=port,
+                    scheme=scheme,
+                ) if scheme in ("http", "https"):
+                    port = port if port else 80
+                    proxy_conf = {
+                        "spark.hadoop.fs.s3a.proxy.host": hostname,
+                        "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
+                        if scheme == "https"
+                        else "false",
+                        "spark.hadoop.fs.s3a.proxy.port": port,
+                    }
+
+                case _:
+                    proxy_conf = {}
+
+        return base_s3_conf | proxy_conf
 
     @property
     def _azure_storage_conf(self) -> dict[str, str]:

--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -86,17 +86,12 @@ class HistoryServerConfig(WithLogging):
             ),
         }
 
-        # Assigns the first non empty proxy url or defaults to an empty string
-        proxy_url = next(
-            filter(
-                None,
-                (
-                    os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
-                    os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
-                ),
-            ),
-            "",
-        )
+        s3_scheme = urlparse(s3.connection_info.endpoint).scheme
+        proxy_url = {
+            "http": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "https": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+        }.get(s3_scheme, os.environ.get("JUJU_CHARM_HTTP_PROXY", ""))
+
         if is_proxy_skipped(s3.connection_info.endpoint):
             proxy_conf: dict[str, str] = {}
         else:

--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -98,7 +98,7 @@ class HistoryServerConfig(WithLogging):
             "",
         )
         if is_proxy_skipped(s3.connection_info.endpoint):
-            proxy_conf = {}
+            proxy_conf: dict[str, str] = {}
         else:
             match urlparse(proxy_url):
                 case ParseResult(
@@ -108,13 +108,13 @@ class HistoryServerConfig(WithLogging):
                     port=port,
                     scheme=scheme,
                 ) if scheme in ("http", "https"):
-                    port = port if port else {"http": 80, "https": 443}.get(scheme)
+                    port_str = str(port) if port else {"http": "80", "https": "443"}[scheme]
                     proxy_conf = {
                         "spark.hadoop.fs.s3a.proxy.host": hostname,
                         "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
                         if scheme == "https"
                         else "false",
-                        "spark.hadoop.fs.s3a.proxy.port": port,
+                        "spark.hadoop.fs.s3a.proxy.port": port_str,
                         "spark.hadoop.fs.s3a.proxy.username": username,
                         "spark.hadoop.fs.s3a.proxy.password": password,
                     }
@@ -126,13 +126,13 @@ class HistoryServerConfig(WithLogging):
                     port=port,
                     scheme=scheme,
                 ) if scheme in ("http", "https"):
-                    port = port if port else {"http": 80, "https": 443}.get(scheme)
+                    port_str = str(port) if port else {"http": "80", "https": "443"}[scheme]
                     proxy_conf = {
                         "spark.hadoop.fs.s3a.proxy.host": hostname,
                         "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
                         if scheme == "https"
                         else "false",
-                        "spark.hadoop.fs.s3a.proxy.port": port,
+                        "spark.hadoop.fs.s3a.proxy.port": port_str,
                     }
 
                 case _:

--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -108,8 +108,7 @@ class HistoryServerConfig(WithLogging):
                     port=port,
                     scheme=scheme,
                 ) if scheme in ("http", "https"):
-                    port = port if port else 80
-
+                    port = port if port else {"http": 80, "https": 443}.get(scheme)
                     proxy_conf = {
                         "spark.hadoop.fs.s3a.proxy.host": hostname,
                         "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"
@@ -127,7 +126,7 @@ class HistoryServerConfig(WithLogging):
                     port=port,
                     scheme=scheme,
                 ) if scheme in ("http", "https"):
-                    port = port if port else 80
+                    port = port if port else {"http": 80, "https": 443}.get(scheme)
                     proxy_conf = {
                         "spark.hadoop.fs.s3a.proxy.host": hostname,
                         "spark.hadoop.fs.s3a.proxy.ssl.enabled": "true"

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -143,6 +143,7 @@ class S3Manager(WithLogging):
                 return False
             except ProxyConnectionError as proxy_error:
                 self.logger.error(f"Could not communicate with/through proxy {proxy_error}")
+                return False
             except Exception as e:
                 self.logger.error(f"S3 related error {e}")
                 return False

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -26,20 +26,20 @@ if TYPE_CHECKING:
 class S3Manager(WithLogging):
     """Class exposing business logic for interacting with S3 service."""
 
-    def __init__(self, config: S3ConnectionInfo):
-        self.config = config
+    def __init__(self, connection_info: S3ConnectionInfo):
+        self.connection_info = connection_info
 
     @cached_property
     def session(self):
         """Return the S3 session to be used when connecting to S3."""
         return boto3.session.Session(
-            aws_access_key_id=self.config.access_key,
-            aws_secret_access_key=self.config.secret_key,
+            aws_access_key_id=self.connection_info.access_key,
+            aws_secret_access_key=self.connection_info.secret_key,
         )
 
     def get_or_create_bucket(self, client: S3Client) -> bool:
         """Create bucket if it does not exists."""
-        bucket_name = self.config.bucket
+        bucket_name = self.connection_info.bucket
         bucket_exists = True
 
         try:
@@ -58,7 +58,7 @@ class S3Manager(WithLogging):
             self._wait_until_exists(client)
             self.logger.info(f"Created bucket {bucket_name}")
 
-        client.put_object(Bucket=bucket_name, Key=os.path.join(self.config.path, ""))
+        client.put_object(Bucket=bucket_name, Key=os.path.join(self.connection_info.path, ""))
 
         return True
 
@@ -70,20 +70,20 @@ class S3Manager(WithLogging):
     )
     def _wait_until_exists(self, client: S3Client):
         """Poll s3 API until resource is found."""
-        client.head_bucket(Bucket=self.config.bucket)
+        client.head_bucket(Bucket=self.connection_info.bucket)
 
     def verify(self) -> bool:
         """Verify S3 credentials and configuration."""
         with tempfile.NamedTemporaryFile() as ca_file:
-            if config := self.config.tls_ca_chain:
-                ca_file.write("\n".join(config).encode())
+            if tls_ca_chain := self.connection_info.tls_ca_chain:
+                ca_file.write("\n".join(tls_ca_chain).encode())
                 ca_file.flush()
 
             s3 = self.session.client(
                 "s3",
-                region_name=self.config.region or "us-east-1",
-                endpoint_url=self.config.endpoint or "https://s3.amazonaws.com",
-                verify=ca_file.name if self.config.tls_ca_chain else None,
+                region_name=self.connection_info.region or "us-east-1",
+                endpoint_url=self.connection_info.endpoint or "https://s3.amazonaws.com",
+                verify=ca_file.name if self.connection_info.tls_ca_chain else None,
                 config=Config(
                     request_checksum_calculation="when_supported",
                     response_checksum_validation="when_supported",

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -13,14 +13,48 @@ from typing import TYPE_CHECKING
 
 import boto3
 from botocore.client import Config
-from botocore.exceptions import ClientError, SSLError
+from botocore.exceptions import ClientError, SSLError, ProxyConnectionError
 from tenacity import retry, retry_if_exception_cause_type, stop_after_attempt, wait_fixed
 
+from urllib.parse import urlparse
+import ipaddress
 from common.utils import WithLogging
 from core.domain import S3ConnectionInfo
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
+
+
+def is_proxy_skipped(endpoint: str) -> bool:
+    """Determine if proxy should not be applied for the given endpoint."""
+    no_proxy_list = os.environ.get("JUJU_CHARM_NO_PROXY", "")
+    if not no_proxy_list:
+        return False
+
+    host = urlparse(endpoint).hostname
+    if not host:
+        return False
+    no_proxy_entries = [
+        entry.strip().lower() for entry in no_proxy_list.split(",") if entry.strip()
+    ]
+    for entry in no_proxy_entries:
+        if host == entry:
+            return True
+        elif entry.startswith(".") and host.endswith(
+            entry
+        ):  # abc.example.com matches .example.com
+            return True
+        elif host.endswith("." + entry):  # abc.example.com matches example.com
+            return True
+        try:
+            if ipaddress.ip_address(host) in ipaddress.ip_network(
+                entry, strict=False
+            ):  # CIDR match
+                return True
+        except (AttributeError, ValueError):
+            continue
+
+    return False
 
 
 class S3Manager(WithLogging):
@@ -74,6 +108,14 @@ class S3Manager(WithLogging):
 
     def verify(self) -> bool:
         """Verify S3 credentials and configuration."""
+        proxy_config: dict[str, str] = {}
+
+        if not is_proxy_skipped(self.connection_info.endpoint or ""):
+            if os.environ.get("JUJU_CHARM_HTTPS_PROXY"):
+                proxy_config["https"] = os.environ["JUJU_CHARM_HTTPS_PROXY"]
+            if os.environ.get("JUJU_CHARM_HTTP_PROXY"):
+                proxy_config["http"] = os.environ["JUJU_CHARM_HTTP_PROXY"]
+
         with tempfile.NamedTemporaryFile() as ca_file:
             if tls_ca_chain := self.connection_info.tls_ca_chain:
                 ca_file.write("\n".join(tls_ca_chain).encode())
@@ -87,6 +129,7 @@ class S3Manager(WithLogging):
                 config=Config(
                     request_checksum_calculation="when_supported",
                     response_checksum_validation="when_supported",
+                    proxies=proxy_config,
                 ),
             )
 
@@ -98,6 +141,8 @@ class S3Manager(WithLogging):
             except SSLError as ssl_error:
                 self.logger.error(f"SSL validation failed... {ssl_error}")
                 return False
+            except ProxyConnectionError as proxy_error:
+                self.logger.error(f"Could not communicate with/through proxy {proxy_error}")
             except Exception as e:
                 self.logger.error(f"S3 related error {e}")
                 return False

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -6,55 +6,21 @@
 
 from __future__ import annotations
 
-import ipaddress
 import os
 import tempfile
 from functools import cached_property
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError, ProxyConnectionError, SSLError
 from tenacity import retry, retry_if_exception_cause_type, stop_after_attempt, wait_fixed
 
-from common.utils import WithLogging
+from common.utils import WithLogging, is_proxy_skipped
 from core.domain import S3ConnectionInfo
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
-
-
-def is_proxy_skipped(endpoint: str) -> bool:
-    """Determine if proxy should not be applied for the given endpoint."""
-    no_proxy_list = os.environ.get("JUJU_CHARM_NO_PROXY", "")
-    if not no_proxy_list:
-        return False
-
-    host = urlparse(endpoint).hostname
-    if not host:
-        return False
-    no_proxy_entries = [
-        entry.strip().lower() for entry in no_proxy_list.split(",") if entry.strip()
-    ]
-    for entry in no_proxy_entries:
-        if host == entry:
-            return True
-        elif entry.startswith(".") and host.endswith(
-            entry
-        ):  # abc.example.com matches .example.com
-            return True
-        elif host.endswith("." + entry):  # abc.example.com matches example.com
-            return True
-        try:
-            if ipaddress.ip_address(host) in ipaddress.ip_network(
-                entry, strict=False
-            ):  # CIDR match
-                return True
-        except (AttributeError, ValueError):
-            continue
-
-    return False
 
 
 class S3Manager(WithLogging):

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -6,18 +6,18 @@
 
 from __future__ import annotations
 
+import ipaddress
 import os
 import tempfile
 from functools import cached_property
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 import boto3
 from botocore.client import Config
-from botocore.exceptions import ClientError, SSLError, ProxyConnectionError
+from botocore.exceptions import ClientError, ProxyConnectionError, SSLError
 from tenacity import retry, retry_if_exception_cause_type, stop_after_attempt, wait_fixed
 
-from urllib.parse import urlparse
-import ipaddress
 from common.utils import WithLogging
 from core.domain import S3ConnectionInfo
 

--- a/tests/unit/test_component_hs_manager.py
+++ b/tests/unit/test_component_hs_manager.py
@@ -13,9 +13,7 @@ def test_s3_proxy_credentials(monkeypatch: MonkeyPatch) -> None:
     # Given
     monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "http://username:password@10.152.193.234:80")
     s3_manager_testing = mock.MagicMock()
-    s3_manager_testing.connection_info.endpoint = mock.PropertyMock(
-        side_effect="https://192.168.1.1"
-    )
+    s3_manager_testing.connection_info.endpoint = "http://192.168.1.1"
 
     config = HistoryServerConfig(None, s3_manager_testing, None, None, None)  # type: ignore
 
@@ -36,9 +34,7 @@ def test_s3_proxy_plain_ip(monkeypatch: MonkeyPatch) -> None:
     proxy_host = "10.152.193.234"
     monkeypatch.setenv("JUJU_CHARM_HTTPS_PROXY", f"http://{proxy_host}")
     s3_manager_testing = mock.MagicMock()
-    s3_manager_testing.connection_info.endpoint = mock.PropertyMock(
-        side_effect="https://192.168.1.1"
-    )
+    s3_manager_testing.connection_info.endpoint = "https://192.168.1.1"
 
     config = HistoryServerConfig(None, s3_manager_testing, None, None, None)  # type: ignore
 

--- a/tests/unit/test_component_hs_manager.py
+++ b/tests/unit/test_component_hs_manager.py
@@ -48,4 +48,4 @@ def test_s3_proxy_plain_ip(monkeypatch: MonkeyPatch) -> None:
     # Then
     assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.host", "") == proxy_host
     assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.ssl.enabled", "") == "false"
-    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.port", 0) == 80
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.port", "0") == "80"

--- a/tests/unit/test_component_hs_manager.py
+++ b/tests/unit/test_component_hs_manager.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Canonical Limited
+# See LICENSE file for licensing details
+
+from unittest import mock
+
+from pytest import MonkeyPatch
+
+from managers.history_server import HistoryServerConfig
+
+
+def test_s3_proxy_credentials(monkeypatch: MonkeyPatch) -> None:
+    """Proxy credentials are properly extracted and passed to the spark properties."""
+    # Given
+    monkeypatch.setenv("JUJU_CHARM_HTTP_PROXY", "http://username:password@10.152.193.234:80")
+    s3_manager_testing = mock.MagicMock()
+    s3_manager_testing.connection_info.endpoint = mock.PropertyMock(
+        side_effect="https://192.168.1.1"
+    )
+
+    config = HistoryServerConfig(None, s3_manager_testing, None, None, None)  # type: ignore
+
+    # When
+    s3_proxy_conf = config._s3_conf
+
+    # Then
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.username", "") == "username"
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.password", "") == "password"
+
+
+def test_s3_proxy_plain_ip(monkeypatch: MonkeyPatch) -> None:
+    """Proper scheme and port are passed to the spark properties.
+
+    Even if https_proxy is pointing to an http domain.
+    """
+    # Given
+    proxy_host = "10.152.193.234"
+    monkeypatch.setenv("JUJU_CHARM_HTTPS_PROXY", f"http://{proxy_host}")
+    s3_manager_testing = mock.MagicMock()
+    s3_manager_testing.connection_info.endpoint = mock.PropertyMock(
+        side_effect="https://192.168.1.1"
+    )
+
+    config = HistoryServerConfig(None, s3_manager_testing, None, None, None)  # type: ignore
+
+    # When
+    s3_proxy_conf = config._s3_conf
+
+    # Then
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.host", "") == proxy_host
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.ssl.enabled", "") == "false"
+    assert s3_proxy_conf.get("spark.hadoop.fs.s3a.proxy.port", 0) == 80

--- a/tests/unit/test_component_s3.py
+++ b/tests/unit/test_component_s3.py
@@ -9,7 +9,7 @@ import pytest
 from moto import mock_aws
 
 from core.domain import S3ConnectionInfo
-from managers.s3 import S3Manager
+from managers.s3 import S3Manager, is_proxy_skipped
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
@@ -114,3 +114,61 @@ def test_path_existing_still_ok_on_verify(s3: S3Client) -> None:
     assert len(buckets := s3.list_buckets()["Buckets"]) == 1
     # Note that the path provided as been transformed into a directory structure
     assert "Contents" in s3.list_objects_v2(Bucket=bucket_name, Prefix="path/", MaxKeys=3)
+
+
+@pytest.mark.parametrize(
+    "no_proxy_env, endpoint, expected",
+    [
+        # Exact hostname match
+        ("example.com", "https://example.com", True),
+        # Domain suffix match
+        (".example.com", "https://sub.example.com", True),
+        # Subdomain match
+        ("example.com", "https://sub.example.com", True),
+        # Host not in no_proxy
+        ("example.com", "https://other.com", False),
+        # IP exact match
+        ("10.1.1.1", "https://10.1.1.1", True),
+        # IP in CIDR
+        ("10.0.0.0/8", "https://10.152.183.1", True),
+        # IP outside CIDR
+        ("10.0.0.0/8", "https://192.168.1.1", False),
+        # Multiple entries in no_proxy
+        ("127.0.0.1,example.com,10.0.0.0/8", "https://10.5.5.5", True),
+        ("127.0.0.1,example.com,10.0.0.0/8", "https://192.168.1.1", False),
+        # Empty no_proxy
+        ("", "https://anything.com", False),
+        # Localhost and loopback IPs
+        ("127.0.0.1,localhost,::1", "http://127.0.0.1", True),
+        ("127.0.0.1,localhost,::1", "http://localhost", True),
+        ("127.0.0.1,localhost,::1", "http://[::1]", True),
+        ("127.0.0.1,localhost,::1", "http://10.0.0.1", False),
+        # Empty endpoint or missing hostname
+        ("example.com", "", False),
+        ("example.com", "file:///tmp/file.txt", False),
+        # Wildcard subdomain edge
+        (".example.com", "https://deep.sub.example.com", True),
+        # Multiple domains / IPs with whitespace
+        (" example.com , 10.0.0.0/8 ,localhost ", "https://10.12.34.56", True),
+        (" example.com , 10.0.0.0/8 ,localhost ", "https://otherhost.com", False),
+        # Invalid CIDR entries (should be ignored)
+        ("10.0.0.0/8,invalid_cidr,example.com", "https://10.1.2.3", True),
+        ("10.0.0.0/8,invalid_cidr,example.com", "https://notexample.com", False),
+        # Endpoint with port number
+        ("example.com", "https://example.com:8080/path", True),
+        ("example.com", "https://other.com:443/path", False),
+        # Mixed case domain (should be case-insensitive)
+        ("EXAMPLE.COM", "https://example.com", True),
+        ("EXAMPLE.COM", "https://Sub.Example.Com", True),
+    ],
+)
+def test_skip_proxy(no_proxy_env, endpoint, expected, monkeypatch):
+    # Given
+    # Patch JUJU_CHARM_NO_PROXY env var
+    monkeypatch.setenv("JUJU_CHARM_NO_PROXY", no_proxy_env)
+
+    # When
+    should_skip_proxy = is_proxy_skipped(endpoint)
+
+    # Then
+    assert should_skip_proxy == expected

--- a/tests/unit/test_component_s3.py
+++ b/tests/unit/test_component_s3.py
@@ -163,6 +163,7 @@ def test_path_existing_still_ok_on_verify(s3: S3Client) -> None:
     ],
 )
 def test_skip_proxy(no_proxy_env, endpoint, expected, monkeypatch):
+    """Test that we are properly detecting that we should skip domains given a NO_PROXY env var."""
     # Given
     # Patch JUJU_CHARM_NO_PROXY env var
     monkeypatch.setenv("JUJU_CHARM_NO_PROXY", no_proxy_env)


### PR DESCRIPTION
This PR aims to address the issues we've been facing on PS7.
Thanks to @theoctober19th for the original fix I took from https://github.com/canonical/object-storage-integrator/pull/86!

## Changes

- Added the fix mentioned above, proxy config is explicitely passed as an empty dict to the boto library if the endpoint is included in NO_PROXY.
- Reworked the history server's spark properties if we need to access the object storage through a proxy
- Reworded a few variables because everything was named "config", git-ignored coverage file

Please note that this PR does not cover proxy configuration for Azure storage, as we settled on doing that in a dedicated ticket. The NO_PROXY issue we've been facing on PS7 would be unlikely anyway, but the workload proxy configuration would be useful to have.

## Testing

- The NO_PROXY issue was successfully tested on PS7 with a local storage
- Using AWS S3 on PS7 through a proxy was successful as well
- I came up with this setup to locally test proxy scenarios. You might find it useful, or perhaps we can even include this at some point in our tests:
1. Create a small system container with 
```shell
lxc init ubuntu:noble proxy -c limits.cpu=1 -c limits.memory=2GB
```
2. Create the following `cloud-init.yaml` configuration (`BasicAuth` optional)

```yaml
#cloud-config
packages:
  - tinyproxy

write_files:
  - path: /home/ubuntu/tiny.conf
    permissions: '0755'
    owner: ubuntu:ubuntu
    defer: true
    content: |
      Port 8080
      Timeout 60
      BasicAuth username password

``` 
3. Pass the cloud-init configuration to the proxy system container
```shell
lxc config set proxy cloud-init.user-data - < cloud-init.yaml
 ```
4. Start and wait for the proxy system container to be configured
```shell
lxc start proxy
lxc exec proxy -- sudo -u ubuntu -i cloud-init status --wait
```
5. Start the proxy
```shell
lxc exec proxy -- sudo -u ubuntu -i tinyproxy -d -c tiny.conf
```
6. You may then use `http://username:password@<proxy-ip>:8080` as the value for your proxy env vars, like for instance `juju model-config juju-http-proxy="http://username:password@10.152.193.65:8080" juju-https-proxy="http://username:password@10.152.193.65:8080"`

