### PR TITLE
[PRA-140] Block charm in case of missing object storage path

### DIFF
--- a/src/core/context.py
+++ b/src/core/context.py
@@ -191,15 +191,18 @@ class Context(WithLogging):
 class Status(Enum):
     """Class bundling all statuses that the charm may fall into."""
 
-    WAITING_PEBBLE = MaintenanceStatus("Waiting for Pebble")
-    MISSING_STORAGE_RELATION = BlockedStatus("Missing relation with storage (s3 or azure storage)")
-    INVALID_S3_CREDENTIALS = BlockedStatus("Invalid S3 credentials")
-    MISSING_INGRESS_RELATION = BlockedStatus("Missing INGRESS relation")
-    NOT_RUNNING = BlockedStatus("History server not running. Please check logs.")
-    MULTIPLE_OBJECT_STORAGE_RELATIONS = BlockedStatus(
-        "Spark History Server can be related to only one storage backend at a time."
+    ACTIVE = ActiveStatus("")
+    INVALID_STORAGE_CREDENTIALS = BlockedStatus(
+        "Invalid object storage credentials or permission issue. Please check logs."
     )
+    MISSING_INGRESS_RELATION = BlockedStatus("Missing INGRESS relation")
+    MISSING_STORAGE_PATH = BlockedStatus("Missing object storage folder path")
+    MISSING_STORAGE_RELATION = BlockedStatus("Missing relation with storage (s3 or azure storage)")
     MULTIPLE_AUTH_PROXY_RELATIONS = BlockedStatus(
         "Spark History Server can be related to only one auth proxy backend (Oauth2proxy or Authkeeper) at a time."
     )
-    ACTIVE = ActiveStatus("")
+    MULTIPLE_OBJECT_STORAGE_RELATIONS = BlockedStatus(
+        "Spark History Server can be related to only one storage backend at a time."
+    )
+    NOT_RUNNING = BlockedStatus("History server not running. Please check logs.")
+    WAITING_PEBBLE = MaintenanceStatus("Waiting for Pebble")

--- a/src/events/base.py
+++ b/src/events/base.py
@@ -19,6 +19,7 @@ from core.context import (
 )
 from core.domain import AzureStorageConnectionInfo
 from core.workload import SparkHistoryWorkloadBase
+from managers.azure_storage import AzureStorageManager
 from managers.s3 import S3Manager
 
 
@@ -41,18 +42,21 @@ class BaseEventHandler(Object):
         if not self.workload.ready():
             return Status.WAITING_PEBBLE.value
 
-        s3 = s3
-
         if not s3 and not azure:
             return Status.MISSING_STORAGE_RELATION.value
 
         if s3 and azure:
             return Status.MULTIPLE_OBJECT_STORAGE_RELATIONS.value
 
-        if s3:
-            s3_manager = S3Manager(s3)
-            if not s3_manager.verify():
-                return Status.INVALID_S3_CREDENTIALS.value
+        if not getattr(s3, "path", None) and not getattr(azure, "path", None):
+            # We already assessed that one of the two is present
+            return Status.MISSING_STORAGE_PATH.value
+
+        if s3 and not S3Manager(s3).verify():
+            return Status.INVALID_STORAGE_CREDENTIALS.value
+
+        if azure and not AzureStorageManager(azure).verify():
+            return Status.INVALID_STORAGE_CREDENTIALS.value
 
         if not self.workload.active():
             return Status.NOT_RUNNING.value

--- a/src/managers/azure_storage.py
+++ b/src/managers/azure_storage.py
@@ -49,6 +49,12 @@ class AzureStorageManager(WithLogging):
                 self._wait_until_exists(self.container_client)
             except RetryError:
                 return False
+        return True
+
+    def ensure_path(self) -> bool:
+        """Create path if it does not exists."""
+        if not self.config.path:
+            return False
 
         blob_client = self.container_client.get_blob_client(
             os.path.join(self.config.path, ".keep")
@@ -83,7 +89,11 @@ class AzureStorageManager(WithLogging):
             return False
 
         if not self.get_or_create_container():
-            self.logger.error("Could not create container or path.")
+            self.logger.error("Could not create container.")
+            return False
+
+        if not self.ensure_path():
+            self.logger.error("Could not create path.")
             return False
 
         return True

--- a/src/managers/s3.py
+++ b/src/managers/s3.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 import tempfile
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import boto3
 from botocore.client import Config
@@ -50,15 +50,39 @@ class S3Manager(WithLogging):
                 return False
             elif "(404)" in ex.args[0]:
                 bucket_exists = False
-        else:
-            self.logger.info(f"Using existing bucket {bucket_name}")
 
         if not bucket_exists:
             client.create_bucket(Bucket=bucket_name)
-            self._wait_until_exists(client)
+            self._wait_until_exists(client, "bucket")
             self.logger.info(f"Created bucket {bucket_name}")
 
-        client.put_object(Bucket=bucket_name, Key=os.path.join(self.connection_info.path, ""))
+        return True
+
+    def ensure_path(self, client: S3Client) -> bool:
+        """Create path if it does not exists."""
+        path = self.connection_info.path
+        path_exists = True
+        if not path:
+            return False
+        try:
+            client.head_object(
+                Bucket=self.connection_info.bucket,
+                Key=os.path.join(path, ".keep"),
+            )
+        except ClientError as ex:
+            if "(403)" in ex.args[0]:
+                self.logger.error("Wrong credentials or access to bucket is forbidden")
+                return False
+            elif "(404)" in ex.args[0]:
+                path_exists = False
+
+        if not path_exists:
+            client.put_object(
+                Bucket=self.connection_info.bucket,
+                Key=os.path.join(path, ".keep"),
+            )
+            self._wait_until_exists(client, "key")
+            self.logger.info(f"Created path {path} in bucket {self.connection_info.bucket}")
 
         return True
 
@@ -68,9 +92,17 @@ class S3Manager(WithLogging):
         retry=retry_if_exception_cause_type(ClientError),
         reraise=True,
     )
-    def _wait_until_exists(self, client: S3Client):
+    def _wait_until_exists(
+        self, client: S3Client, resource_type: Literal["bucket", "key"]
+    ) -> None:
         """Poll s3 API until resource is found."""
-        client.head_bucket(Bucket=self.connection_info.bucket)
+        if resource_type == "bucket":
+            client.head_bucket(Bucket=self.connection_info.bucket)
+        else:
+            client.head_object(
+                Bucket=self.connection_info.bucket,
+                Key=os.path.join(self.connection_info.path, ".keep"),
+            )
 
     def verify(self) -> bool:
         """Verify S3 credentials and configuration."""
@@ -117,4 +149,4 @@ class S3Manager(WithLogging):
             if not self.get_or_create_bucket(s3):
                 return False
 
-        return True
+        return self.ensure_path(s3)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -200,3 +200,27 @@ def azure_storage_relation():
             "secret-key": "some-secret",
         },
     )
+
+
+@pytest.fixture
+def azure_storage_relation_no_path():
+    """Provide fixture for the Azure storage relation."""
+    relation = Relation(
+        endpoint=AZURE_RELATION_NAME,
+        interface="azure_storage",
+        remote_app_name="azure-storage-integrator",
+    )
+    relation_id = relation.id
+
+    return replace(
+        relation,
+        local_app_data={"container": f"relation-{relation_id}"},
+        remote_app_data={
+            "container": "my-bucket",
+            "data": f'{{"container": "relation-{relation_id}"}}',
+            "path": "",
+            "storage-account": "test-storage-account",
+            "connection-protocol": "abfss",
+            "secret-key": "some-secret",
+        },
+    )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,6 +88,30 @@ def s3_relation():
 
 
 @pytest.fixture
+def s3_relation_no_path():
+    """Provide fixture for the S3 relation."""
+    relation = Relation(
+        endpoint=S3,
+        interface="s3",
+        remote_app_name="s3-integrator",
+    )
+    relation_id = relation.id
+
+    return replace(
+        relation,
+        local_app_data={"bucket": f"relation-{relation_id}"},
+        remote_app_data={
+            "access-key": "access-key",
+            "bucket": "my-bucket",
+            "data": f'{{"bucket": "relation-{relation_id}"}}',
+            "endpoint": "https://s3.endpoint",
+            "path": "",
+            "secret-key": "secret-key",
+        },
+    )
+
+
+@pytest.fixture
 def s3_relation_tls():
     """Provide fixture for the S3 relation."""
     relation = Relation(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -175,7 +175,7 @@ def test_s3_relation_connection_ko(
     assert out.unit_status == Status.INVALID_STORAGE_CREDENTIALS.value
 
 
-@patch("managers.s3.S3Manager.verify", return_value=True)
+@patch("managers.s3.S3Manager.verify", return_value=False)
 @patch("workload.SparkHistoryServer.exec")
 def test_s3_relation_no_path_ko(
     exec_calls,
@@ -368,6 +368,31 @@ def test_azure_storage_relation(
         ]
         == azure_storage_relation.remote_app_data["secret-key"]
     )
+
+
+@patch("managers.azure_storage.AzureStorageManager.verify", return_value=False)
+@patch("workload.SparkHistoryServer.exec")
+def test_azure_relation_no_path_ko(
+    exec_calls,
+    verify_call,
+    history_server_ctx: Context[SparkHistoryServerCharm],
+    history_server_container: Container,
+    azure_storage_relation_no_path: Relation,
+) -> None:
+    """Assert that a missing path in the Azure Storage relation leads to a blocked state."""
+    # Given
+    state = State(
+        relations=[azure_storage_relation_no_path],
+        containers=[history_server_container],
+    )
+
+    # When
+    out = history_server_ctx.run(
+        history_server_ctx.on.relation_changed(azure_storage_relation_no_path), state
+    )
+
+    # Then
+    assert out.unit_status == Status.MISSING_STORAGE_PATH.value
 
 
 @patch("managers.s3.S3Manager.verify", return_value=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-from ops import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Container, Context, Relation, State
 
 from constants import CONTAINER
+from core.context import Status
 
 if TYPE_CHECKING:
     from charm import SparkHistoryServerCharm
@@ -40,7 +40,7 @@ def test_start_history_server(history_server_ctx: Context[SparkHistoryServerChar
         containers=[Container(name=CONTAINER, can_connect=False)],
     )
     out = history_server_ctx.run(history_server_ctx.on.install(), state)
-    assert out.unit_status == MaintenanceStatus("Waiting for Pebble")
+    assert out.unit_status == Status.WAITING_PEBBLE.value
 
 
 @patch("workload.SparkHistoryServer.exec")
@@ -55,7 +55,7 @@ def test_pebble_ready(
     out = history_server_ctx.run(
         history_server_ctx.on.pebble_ready(history_server_container), state
     )
-    assert out.unit_status == BlockedStatus("Missing relation with storage (s3 or azure storage)")
+    assert out.unit_status == Status.MISSING_STORAGE_RELATION.value
 
 
 @patch("managers.s3.S3Manager.verify", return_value=True)
@@ -73,7 +73,7 @@ def test_s3_relation_connection_ok(
         containers=[history_server_container],
     )
     out = history_server_ctx.run(history_server_ctx.on.relation_changed(s3_relation), state)
-    assert out.unit_status == ActiveStatus("")
+    assert out.unit_status == Status.ACTIVE.value
 
     # Check containers modifications
     assert len(out.get_container(CONTAINER).layers) == 2
@@ -114,7 +114,7 @@ def test_s3_relation_connection_ok_tls(
         containers=[history_server_container],
     )
     inter = history_server_ctx.run(history_server_ctx.on.relation_changed(s3_relation_tls), state)
-    assert inter.unit_status == ActiveStatus("")
+    assert inter.unit_status == Status.ACTIVE.value
 
     # Check containers modifications
     assert len(inter.get_container(CONTAINER).layers) == 2
@@ -172,7 +172,32 @@ def test_s3_relation_connection_ko(
         containers=[history_server_container],
     )
     out = history_server_ctx.run(history_server_ctx.on.relation_changed(s3_relation), state)
-    assert out.unit_status == BlockedStatus("Invalid S3 credentials")
+    assert out.unit_status == Status.INVALID_STORAGE_CREDENTIALS.value
+
+
+@patch("managers.s3.S3Manager.verify", return_value=True)
+@patch("workload.SparkHistoryServer.exec")
+def test_s3_relation_no_path_ko(
+    exec_calls,
+    verify_call,
+    history_server_ctx: Context[SparkHistoryServerCharm],
+    history_server_container: Container,
+    s3_relation_no_path: Relation,
+) -> None:
+    """Assert that a missing path in the S3 relation leads to a blocked state."""
+    # Given
+    state = State(
+        relations=[s3_relation_no_path],
+        containers=[history_server_container],
+    )
+
+    # When
+    out = history_server_ctx.run(
+        history_server_ctx.on.relation_changed(s3_relation_no_path), state
+    )
+
+    # Then
+    assert out.unit_status == Status.MISSING_STORAGE_PATH.value
 
 
 @patch("managers.s3.S3Manager.verify", return_value=True)
@@ -197,9 +222,7 @@ def test_s3_relation_broken(
         history_server_ctx.on.relation_broken(s3_relation), state_after_relation_changed
     )
 
-    assert state_after_relation_broken.unit_status == BlockedStatus(
-        "Missing relation with storage (s3 or azure storage)"
-    )
+    assert state_after_relation_broken.unit_status == Status.MISSING_STORAGE_RELATION.value
 
     spark_properties = parse_spark_properties(state_after_relation_broken, tmp_path)
 
@@ -220,7 +243,7 @@ def test_ingress_relation_creation(
         containers=[history_server_container],
     )
     out = history_server_ctx.run(history_server_ctx.on.relation_changed(ingress_relation), state)
-    assert out.unit_status == BlockedStatus("Missing relation with storage (s3 or azure storage)")
+    assert out.unit_status == Status.MISSING_STORAGE_RELATION.value
 
 
 @patch("managers.s3.S3Manager.verify", return_value=True)
@@ -240,7 +263,7 @@ def test_with_ingress(
     )
     out = history_server_ctx.run(history_server_ctx.on.relation_changed(ingress_relation), state)
 
-    assert out.unit_status == ActiveStatus("")
+    assert out.unit_status == Status.ACTIVE.value
 
     spark_properties = parse_spark_properties(out, tmp_path)
 
@@ -267,7 +290,7 @@ def test_with_ingress_subdomain(
         history_server_ctx.on.relation_changed(ingress_subdomain_relation), state
     )
 
-    assert out.unit_status == ActiveStatus("")
+    assert out.unit_status == Status.ACTIVE.value
 
     spark_properties = parse_spark_properties(out, tmp_path)
 
@@ -292,7 +315,7 @@ def test_remove_ingress(
     )
     out = history_server_ctx.run(history_server_ctx.on.relation_broken(ingress_relation), state)
 
-    assert out.unit_status == ActiveStatus("")
+    assert out.unit_status == Status.ACTIVE.value
 
     spark_properties = parse_spark_properties(out, tmp_path)
 
@@ -317,7 +340,7 @@ def test_azure_storage_relation(
     out = history_server_ctx.run(
         history_server_ctx.on.relation_changed(azure_storage_relation), state
     )
-    assert out.unit_status == ActiveStatus("")
+    assert out.unit_status == Status.ACTIVE.value
 
     # Check containers modifications
     assert len(out.get_container(CONTAINER).layers) == 2
@@ -373,9 +396,7 @@ def test_azure_storage_relation_broken(
         state_after_relation_changed,
     )
 
-    assert state_after_relation_broken.unit_status == BlockedStatus(
-        "Missing relation with storage (s3 or azure storage)"
-    )
+    assert state_after_relation_broken.unit_status == Status.MISSING_STORAGE_RELATION.value
 
     spark_properties = parse_spark_properties(state_after_relation_broken, tmp_path)
 
@@ -403,6 +424,4 @@ def test_both_azure_storage_and_s3_relation_together(
     out = history_server_ctx.run(
         history_server_ctx.on.relation_changed(azure_storage_relation), state
     )
-    assert out.unit_status == BlockedStatus(
-        "Spark History Server can be related to only one storage backend at a time."
-    )
+    assert out.unit_status == Status.MULTIPLE_OBJECT_STORAGE_RELATIONS.value


### PR DESCRIPTION
## Changes

This PR addresses #127.

We were already taking care of creating a `.keep` file to ensure that the path was present in the object storage. Now this approach is standardized between S3 and Azure Storage.


I had to refactor a thing or two to make the linter happy (especially when it comes to cyclomatic complexity), but I also noticed a few things to be improved. I'll do that as part of a future housekeeping PR adding type checking to the lint tox env 