### PR TITLE
[BACKPORT] Always clear the truststore before recreating new one

### DIFF
--- a/src/managers/history_server.py
+++ b/src/managers/history_server.py
@@ -237,16 +237,13 @@ class HistoryServerManager(WithLogging):
         ):
             self.logger.info("Neither S3 nor Azure Storage are ready")
             return
-        if s3:
-            if tls_ca_chain := s3.tls_ca_chain:
-                self.tls.import_ca("\n".join(tls_ca_chain))
-                self.workload.set_environment(
-                    {
-                        "SPARK_HISTORY_OPTS": f"-Djavax.net.ssl.trustStore={self.workload.paths.truststore} "
-                        f"-Djavax.net.ssl.trustStorePassword={self.tls.truststore_password}"
-                    }
-                )
-            else:
-                self.workload.set_environment({"SPARK_HISTORY_OPTS": ""})
+        if s3 and (tls_ca_chain := s3.tls_ca_chain):
+            self.tls.import_ca("\n".join(tls_ca_chain))
+            self.workload.set_environment(
+                {
+                    "SPARK_HISTORY_OPTS": f"-Djavax.net.ssl.trustStore={self.workload.paths.truststore} "
+                    f"-Djavax.net.ssl.trustStorePassword={self.tls.truststore_password}"
+                }
+            )
 
         self.workload.start()

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -78,3 +78,4 @@ class TLSManager(WithLogging):
         """Remove all files related to TLS configuration."""
         self.workload.exec(["rm", "-f", str(self.workload.paths.truststore)])
         self.workload.exec(["rm", "-f", str(self.workload.paths.cert)])
+        self.workload.set_environment({"SPARK_HISTORY_OPTS": ""})

--- a/tests/integration/test_charm_tls.py
+++ b/tests/integration/test_charm_tls.py
@@ -12,6 +12,7 @@ from time import sleep
 
 import jubilant
 import yaml
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from .test_helpers import (
     get_certificate_from_file,
@@ -87,12 +88,21 @@ def test_build_and_deploy(
     logger.info("Relating history server charm with s3-integrator charm")
 
     juju.integrate(charm_versions.s3.application_name, APP_NAME)
-    status = juju.wait(jubilant.all_active, delay=5)
+    status = juju.wait(jubilant.all_active, delay=10)
 
     logger.info("Verifying history server has no app entries")
 
     address = status.apps[APP_NAME].units[f"{APP_NAME}/0"].address
-    apps = json.loads(urllib.request.urlopen(f"http://{address}:18080/api/v1/applications").read())
+
+    apps = []
+    try:
+        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(3)):
+            with attempt:
+                apps = json.loads(
+                    urllib.request.urlopen(f"http://{address}:18080/api/v1/applications").read()
+                )
+    except RetryError as e:
+        raise AssertionError(f"History server API was not ready in time: {e}") from e
 
     assert len(apps) == 0
 
@@ -118,6 +128,7 @@ def test_build_and_deploy(
 
     logger.info("Verifying history server has 1 app entry")
 
+    apps = []
     for _ in range(0, 5):
         try:
             apps = json.loads(


### PR DESCRIPTION
This PR backports a few changes we pushed to `4/edge` via PR #156, specifically
1. Clearing truststore before recreating new one (the clearing should be done unconditionally)
2. Add retry to one of the integration test steps, to reduce flakiness.