### PR TITLE
[PRA-74] Renovate configuration to update OCI resource

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,5 +10,23 @@
     "enabled": true,
     "schedule": ["* 1-6 1-7 * 5"]
   },
-  "ignoreDeps": ["ubuntu"]
+  "ignoreDeps": ["ubuntu"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)metadata\\.yaml$"],
+      "matchStrings": [
+        "upstream-source:\\s*(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/canonical/charmed-spark"],
+      "pinDigests": true,
+      "allowedVersions": "/^3\\.5-/"
+    }
+  ]
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -33,8 +33,7 @@ resources:
   spark-history-server-image:
     type: oci-image
     description: OCI image for Spark History Server
-    # 3.5.7-22.04, release date 16/03/2026
-    upstream-source: ghcr.io/canonical/charmed-spark@sha256:f7f387a76ba2f3b6cfc34a35f36c0f4ae85bfa78c8c9d4bfa06ba86401b95d70
+    upstream-source: ghcr.io/canonical/charmed-spark:3.5-22.04_edge@sha256:f7f387a76ba2f3b6cfc34a35f36c0f4ae85bfa78c8c9d4bfa06ba86401b95d70
 
 requires:
   s3-credentials:


### PR DESCRIPTION
This PR adds the configuration needed for renovate to pick up newer rock releases.
Since this is difficult to demonstrate in a PR, here is how it looks in my private fork: https://github.com/Batalex/spark-history-server-k8s-operator/pull/1

We can see that the SHA was indeed updated. We must be careful to have the multi-arch manifest in this field when we enable the configuration; otherwise, Renovate will stick with the original architecture.

Big thanks to Paolo who laid the groundwork for this feature.