### PR TITLE
[PRA-264] Improve TIOBE workflow reliability

### DIFF
--- a/.github/workflows/tiobe_scan.yaml
+++ b/.github/workflows/tiobe_scan.yaml
@@ -18,13 +18,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y python3-venv
-
-      - name: Install pipx
-        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
-
-      - name: Add pipx to PATH
-        run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+        run: |
+          sudo apt update
+          sudo apt install -y pipx python3-venv
+          pipx ensurepath
 
       - name: Install tox and poetry using pipx
         run: |


### PR DESCRIPTION
As part of the ticket on fixing the workflow for Kyuubi, I noticed that this workflow is quite flaky here, at around a 50% success rate.

All failed runs that I checked were about failing to install/configure pipx. Therefore, I'm bringing here the improvements done as part of https://github.com/canonical/kyuubi-k8s-operator/pull/212.
