### PR TITLE
[MISC] Fix Github Token permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,8 @@ jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
+    permissions:
+      actions: read
 
   release-charm:
     name: Release charm


### PR DESCRIPTION
Needed to unblock release for 3/edge, has been failing since a couple of weeks.