### PR TITLE
[PRA-354] Migrate and improve renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,32 +1,45 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
     "github>canonical/data-platform//renovate_presets/charm.json5",
+    "helpers:pinGitHubActionDigests",
   ],
-  "reviewers": ["team:processing"],
-  // Between 1AM and 6:59AM, first Friday of the month
-  "schedule": ["* 1-6 1-7 * 5"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["* 1-6 1-7 * 5"]
+  // Between 1AM and 6:59AM, Friday mid-month
+  schedule: ["* 1-6 14-21 * 5"],
+  lockFileMaintenance: {
+    enabled: true,
+    // Between 1AM and 6:59AM, first Friday of the month
+    schedule: ["* 1-6 1-7 * 5"],
   },
-  "ignoreDeps": ["ubuntu"],
-  "customManagers": [
+  commitMessagePrefix: "[RENOVATE] ",
+  ignoreDeps: ["ubuntu"],
+  customManagers: [
     {
-      "customType": "regex",
-      "fileMatch": ["(^|/)metadata\\.yaml$"],
-      "matchStrings": [
-        "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"
+      customType: "regex",
+      managerFilePatterns: ["metadata.yaml"],
+      matchStrings: [
+        "#\\s*oci-tag=(?<currentValue>[^\\s]+)\\r?\\n\\s*upstream-source:\\s*(?<depName>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)",
       ],
-      "datasourceTemplate": "docker"
-    }
+      datasourceTemplate: "docker",
+    },
   ],
-  "packageRules": [
+  packageRules: [
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/canonical/charmed-spark"],
-      "pinDigests": true,
-      "allowedVersions": "/^3\\.5-/"
-    }
-  ]
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/canonical/charmed-spark"],
+      pinDigests: true,
+      allowedVersions: "/^3\\.5-/",
+    },
+    {
+      description: "Combine all charmcraft|charmcraft.yaml dependencies into a single PR",
+      matchFileNames: ["charmcraft.yaml", "metadata.yaml"],
+      groupName: "Charm dependencies",
+      groupSlug: "charm-deps",
+    },
+    {
+      description: "Require manual approval on Dashboard for major updates",
+      matchUpdateTypes: ["major"],
+      dependencyDashboardApproval: true,
+    },
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     "github>canonical/data-platform//renovate_presets/charm.json5",
     "helpers:pinGitHubActionDigests",
   ],
+  baseBranchPatterns: ["/^3\\/edge$/", "/^4\\/edge$/"],
+  useBaseBranchConfig: "merge",
   // Between 1AM and 6:59AM, Friday mid-month
   schedule: ["* 1-6 14-21 * 5"],
   lockFileMaintenance: {


### PR DESCRIPTION
This PR follows and adapts parts of https://github.com/canonical/charmed-spark-rock/pull/261.

Changes: 
- Migrated to the new renovate syntax, format with prettier
- Removed the auto reviewer assignment since we have a CODEOWNERS
- Changed the schedule:
    - Since we keep the "1st friday of the month" schedule for the rock, this repository (and all others using our rocks as inputs) delays the OCI update by two weeks. What I have in mind is basically: start of the month, we handle renovate updates on the rocks for the following two weeks, then we get the renovate updates for the charms and snap, for another couple of weeks and the cycle continues. The bundle would most likely be scheduled on the first friday as well, to balance the # of PR we have in a month
    - However, the lockfile maintenance stays on the first friday of the month. The reason for that is because one major pain point of our current setup is to resolve conflicts on the `poetry.lock` file. If we merge one of the "Update python deps" PR, then we need to completely redo the Lockfile PR and vice-versa. By keeping the lockfile PR on the first friday I hope we can reduce the # of re-triggers we need to do to solve conflicts.
- Reduced the # of PRs:
     - charmcraft.yaml and metadata.yaml (OCI updates) are now batched together in a single PR
     - Major updates now require a manual trigger in the [dependency dashboard](https://github.com/canonical/spark-history-server-k8s-operator/issues/89). The goal is here to avoid "duplicated" PRs (= one PR to update this github action to v51, another to update the action to v50.1.2). Considering that major update could require additional changes, this seemed like the reasonable thing to do
- Pinned GH actions to their digest
- Added `[RENOVATE] ` prefix to the commits and PRs
- Enabled renovate on 4/edge

On my fork, this configuration led to the following PR (based on the current state of this repository)
<img width="1311" height="163" alt="image" src="https://github.com/user-attachments/assets/33fd7c41-f8ec-411e-8348-6843cc49f943" />
